### PR TITLE
Update the filename for GCD proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ the following commands:
 
 ````bash
 $ cd fotc/src/fot
-$ agda LTC-PCF/Program/GCD/Partial/GCD.agda
+$ agda LTC-PCF.Program.GCD.Partial.CorrectnessProof.agda
 ````
 
 More examples

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ the following commands:
 
 ````bash
 $ cd fotc/src/fot
-$ agda LTC-PCF.Program.GCD.Partial.CorrectnessProof.agda
+$ agda LTC-PCF/Program/GCD/Partial/CorrectnessProof.agda
 ````
 
 More examples

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ the following commands:
 
 ````bash
 $ cd fotc/src/fot
-$ agda LTC-PCF/Program/GCD/Partial/ProofSpecification.agda
+$ agda LTC-PCF/Program/GCD/Partial/GCD.agda
 ````
 
 More examples

--- a/src/fot/FOL/Base.agda
+++ b/src/fot/FOL/Base.agda
@@ -18,7 +18,7 @@ infixr 0 _⇔_
 open import Common.FOL.FOL public
 
 ------------------------------------------------------------------------------
--- We added extra symbols for the implication, the bicondicional and
+-- We added extra symbols for the implication, the biconditional and
 -- the universal quantification (see module Common.FOL.FOL).
 
 -- The implication data type.


### PR DESCRIPTION
The file  `LTC-PCF/Program/GCD/Partial/ProofSpecification.agda` does not exist. 
